### PR TITLE
Add gpt-4o-mini support

### DIFF
--- a/src/openai/chatGPT.ts
+++ b/src/openai/chatGPT.ts
@@ -24,6 +24,10 @@ export const CHAT_MODELS = {
 		name: 'gpt-4o',
 		tokenLimit: 128000
 	},
+	GPT_4o_MINI: {
+		name: 'gpt-4o-mini',
+		tokenLimit: 16384
+	},
 	GPT_4: {
 		name: 'gpt-4',
 		tokenLimit: 8192


### PR DESCRIPTION
Adds `gpt-4o-mini` to model list

Token limit: 16384 (Source: https://platform.openai.com/docs/models/gpt-4o-mini)