### PR TITLE
Add Custom Model Support and Configurable API URL

### DIFF
--- a/src/openai/chatGPT.ts
+++ b/src/openai/chatGPT.ts
@@ -1,7 +1,11 @@
 import { request, RequestUrlParam } from 'obsidian'
 import { openai } from './chatGPT-types'
 
-export const OPENAI_COMPLETIONS_URL = `https://api.openai.com/v1/chat/completions`
+export const DEFAULT_OPENAI_COMPLETIONS_URL = `https://api.openai.com/v1/chat/completions`
+
+export const getOpenAICompletionsURL = (configuredUrl?: string): string => {
+	return configuredUrl || DEFAULT_OPENAI_COMPLETIONS_URL
+}
 
 export type ChatModelSettings = {
 	name: string,
@@ -62,6 +66,10 @@ export const CHAT_MODELS = {
 	GPT_4_32K_0613: {
 		name: 'gpt-4-32k-0613',
 		tokenLimit: 32768
+	},
+	CUSTOMIZE: {
+		name: 'customize',
+		tokenLimit: 0
 	}
 }
 
@@ -89,15 +97,19 @@ export async function getChatGPTCompletion(
 	messages: openai.CreateChatCompletionRequest['messages'],
 	settings?: Partial<
 		Omit<openai.CreateChatCompletionRequest, 'messages' | 'model'>
-	>
+	>,
+	customModelName?: string
 ): Promise<string | undefined> {
 	const headers = {
 		Authorization: `Bearer ${apiKey}`,
 		'Content-Type': 'application/json'
 	}
+	const actualModel = model === CHAT_MODELS.CUSTOMIZE.name && customModelName 
+		? customModelName 
+		: (model ?? CHAT_MODELS.GPT_35_TURBO.name)
 	const body: openai.CreateChatCompletionRequest = {
 		messages,
-		model,
+		model: actualModel,
 		...settings
 	}
 	const requestParam: RequestUrlParam = {

--- a/src/settings/ChatStreamSettings.ts
+++ b/src/settings/ChatStreamSettings.ts
@@ -1,4 +1,4 @@
-import { CHAT_MODELS, OPENAI_COMPLETIONS_URL } from 'src/openai/chatGPT'
+import { CHAT_MODELS, DEFAULT_OPENAI_COMPLETIONS_URL } from 'src/openai/chatGPT'
 
 export interface ChatStreamSettings {
 	/**
@@ -15,6 +15,11 @@ export interface ChatStreamSettings {
 	 * The GPT model to use
 	 */
 	apiModel: string
+
+	/**
+	 * Custom model name when using customize option
+	 */
+	customModelName: string
 
 	/**
 	 * The temperature to use when generating responses (0-2). 0 means no randomness.
@@ -57,8 +62,9 @@ Use step-by-step reasoning. Be brief.
 
 export const DEFAULT_SETTINGS: ChatStreamSettings = {
 	apiKey: '',
-	apiUrl: OPENAI_COMPLETIONS_URL,
+	apiUrl: DEFAULT_OPENAI_COMPLETIONS_URL,
 	apiModel: CHAT_MODELS.GPT_35_TURBO.name,
+	customModelName: '',
 	temperature: 1,
 	systemPrompt: DEFAULT_SYSTEM_PROMPT,
 	debug: false,

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -1,6 +1,7 @@
 import { App, PluginSettingTab, Setting } from 'obsidian'
 import { ChatStreamPlugin } from 'src/ChatStreamPlugin'
 import { getModels } from './ChatStreamSettings'
+import { CHAT_MODELS } from 'src/openai/chatGPT'
 
 export class SettingsTab extends PluginSettingTab {
 	plugin: ChatStreamPlugin
@@ -26,8 +27,25 @@ export class SettingsTab extends PluginSettingTab {
 				cb.onChange(async (value) => {
 					this.plugin.settings.apiModel = value
 					await this.plugin.saveSettings()
+					// Trigger refresh to show/hide custom model input
+					this.display()
 				})
 			})
+
+		if (this.plugin.settings.apiModel === CHAT_MODELS.CUSTOMIZE.name) {
+			new Setting(containerEl)
+				.setName('Custom Model Name')
+				.setDesc('Enter the name of your custom model')
+				.addText((text) => {
+					text
+						.setPlaceholder('e.g., gpt-4-1106-vision-preview')
+						.setValue(this.plugin.settings.customModelName)
+						.onChange(async (value) => {
+							this.plugin.settings.customModelName = value
+							await this.plugin.saveSettings()
+						})
+				})
+		}
 
 		new Setting(containerEl)
 			.setName('API key')


### PR DESCRIPTION
## Why
- Enable users to use newer or custom OpenAI or compatibility models that are not pre-defined in the plugin
- Allow users to configure custom API endpoints for compatibility with OpenAI-compatible APIs
- Skip token counting for custom models since their context limits may vary

## What
### Added Features
1. New "customize" option in model selection dropdown
   - When selected, shows an additional input field for custom model name
   - Users can input any valid model identifier (e.g., gpt-4-1106-vision-preview)

2. Made OpenAI API URL configurable
   - Moved hardcoded URL to a configurable setting
   - Maintains the default OpenAI endpoint as fallback
   - Allows users to use alternative API endpoints

### Technical Changes
1. Added `CUSTOMIZE` option to `CHAT_MODELS`
2. Added `customModelName` field to settings
3. Modified token counting logic to skip for custom models
4. Updated settings UI to dynamically show/hide custom model input
5. Enhanced type safety and error handling
6. Maintained backward compatibility with existing configurations

## Testing
- [x] Custom model name input appears when "customize" is selected
- [x] Token counting is skipped for custom models
- [x] Default OpenAI URL is preserved when no custom URL is set
- [x] All TypeScript type checks pass
- [x] Worked for next models / endpoints
  - [x] grok-beta(https://api.x.ai/v1/chat/completions)
  - [x] gemini-flash-1.5(https://generativelanguage.googleapis.com/v1beta/openai/chat/completions)